### PR TITLE
Fix/register for reflection

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 release:
-  current-version: 1.1.0
-  next-version: 1.1.1-SNAPSHOT
+  current-version: 1.1.1
+  next-version: 1.1.2-SNAPSHOT
 

--- a/deployment/src/main/java/io/quarkiverse/opentracing/datadog/deployment/DatadogOpentracingProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/opentracing/datadog/deployment/DatadogOpentracingProcessor.java
@@ -2,6 +2,12 @@ package io.quarkiverse.opentracing.datadog.deployment;
 
 import java.util.function.BooleanSupplier;
 
+import javax.inject.Inject;
+
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.IndexView;
+import org.jboss.jandex.Type;
+
 import io.quarkiverse.opentracing.datadog.DatadogTracerConfig;
 import io.quarkiverse.opentracing.datadog.DatadogTracerInitializer;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
@@ -9,7 +15,10 @@ import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.CapabilityBuildItem;
+import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveHierarchyBuildItem;
 
 /**
  * Add support for Datadog tracer implementation.
@@ -17,6 +26,10 @@ import io.quarkus.deployment.builditem.FeatureBuildItem;
 class DatadogOpentracingProcessor {
 
     private static final String FEATURE = "datadog-opentracing";
+
+    private static final DotName DATADOG_TRACE_PACKAGE = DotName.createSimple("datadog.trace");
+    private static final String BOOLEAN_UTILITY_CLASS = "java.lang.Boolean";
+    private static final String STRING_UTILITY_CLASS = "java.lang.String";
 
     public static class DatadogTracerEnabled implements BooleanSupplier {
 
@@ -27,6 +40,9 @@ class DatadogOpentracingProcessor {
             return buildConfig.enabled;
         }
     }
+
+    @Inject
+    CombinedIndexBuildItem combinedIndexBuildItem;
 
     @BuildStep(onlyIf = DatadogTracerEnabled.class)
     FeatureBuildItem feature() {
@@ -39,9 +55,34 @@ class DatadogOpentracingProcessor {
     }
 
     @BuildStep(onlyIf = DatadogTracerEnabled.class)
-    void buildDatadogInitializer(BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
+    void register(//
+            BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
+            BuildProducer<ReflectiveHierarchyBuildItem> reflectiveHierarchyClass,
+            BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
+
+        IndexView index = combinedIndexBuildItem.getIndex();
+
+        index.getAllKnownSubclasses(DATADOG_TRACE_PACKAGE)
+                .forEach(classInfo -> {
+
+                    addReflectiveHierarchyClass(classInfo.asClass()
+                            .name(), reflectiveHierarchyClass);
+
+                });
+
+        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, BOOLEAN_UTILITY_CLASS));
+        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, STRING_UTILITY_CLASS));
 
         additionalBeans
                 .produce(AdditionalBeanBuildItem.unremovableOf(DatadogTracerInitializer.class));
+    }
+
+    private void addReflectiveHierarchyClass(DotName className,
+            BuildProducer<ReflectiveHierarchyBuildItem> reflectiveHierarchyClass) {
+        Type jandexType = Type.create(className, Type.Kind.CLASS);
+        reflectiveHierarchyClass.produce(new ReflectiveHierarchyBuildItem.Builder().type(jandexType)
+                .source(getClass().getSimpleName() + " > " + jandexType.name()
+                        .toString())
+                .build());
     }
 }


### PR DESCRIPTION
Fix reflection issues introduced by latest changes.
The extension will now register for reflection all datadog.trace.* classes, including the String & Boolean for their static methods as datadog use it.