### PR TITLE
Integration/dd 0.93.0

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 release:
-  current-version: 1.1.3
-  next-version: 1.1.4-SNAPSHOT
+  current-version: 1.1.4
+  next-version: 1.1.5-SNAPSHOT
 

--- a/integration-tests/src/main/resources/application.properties
+++ b/integration-tests/src/main/resources/application.properties
@@ -1,4 +1,7 @@
-quarkus.native.additional-build-args=--allow-incomplete-classpath
 
 quarkus.jaeger.enabled=false
 quarkus.datadog.enabled=true
+
+# Disable health metrics to avoid the dogstatD client to start when application startup
+# This extension is for tracing only and does support the dogstatD client but does not care about it
+dd.trace.health.metrics.enabled=false

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     
     <quarkus.version>2.6.2.Final</quarkus.version>
     <datadog-tracing.version>0.93.0</datadog-tracing.version>
-    <datadog-dogstatsd.version>2.13.0</datadog-dogstatsd.version>
+    <datadog-dogstatsd.version>4.0.0</datadog-dogstatsd.version>
     <moshi.version>1.12.0</moshi.version>
 	
   </properties>


### PR DESCRIPTION
Integrate latest version of dd-java libraries. This include the fix for OT33 classes.
Datadog also finally upgraded their dogstatD dependency on the latest version.

Added some datadog property to avoid the dogstatD to start & report health check data on application startup in the integration tests.